### PR TITLE
Support shenango threads in folly

### DIFF
--- a/apps/test/Makefile
+++ b/apps/test/Makefile
@@ -1,0 +1,34 @@
+# Makefile for simple app
+ROOT_PATH=../..
+include $(ROOT_PATH)/build/shared.mk
+
+test_src = test_atomic.cc
+test_obj = $(test_src:.cc=.o)
+
+librt_libs = $(ROOT_PATH)/bindings/cc/librt++.a
+INC += -I$(ROOT_PATH)/bindings/cc
+
+RUNTIME_LIBS := $(RUNTIME_LIBS) -lnuma
+
+all: test
+
+test: $(test_obj) $(librt_libs) $(RUNTIME_DEPS)
+	$(LDXX) -o $@ $(LDFLAGS) $(test_obj) \
+	$(librt_libs) $(RUNTIME_LIBS)
+
+src = $(test_src)
+obj = $(src:.cc=.o)
+dep = $(obj:.o=.d)
+
+ifneq ($(MAKECMDGOALS),clean)
+-include $(dep)
+endif
+
+%.d: %.cc
+	@$(CXX) $(CXXFLAGS) $< -MM -MT $(@:.d=.o) >$@
+%.o: %.cc
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+.PHONY: clean
+clean:
+	rm -f $(obj) $(dep) test

--- a/apps/test/Makefile
+++ b/apps/test/Makefile
@@ -2,21 +2,28 @@
 ROOT_PATH=../..
 include $(ROOT_PATH)/build/shared.mk
 
-test_src = test_atomic.cc
-test_obj = $(test_src:.cc=.o)
+test_atomic_src = test_atomic.cc
+test_atomic_obj = $(test_atomic_src:.cc=.o)
+
+test_memory_order_src = test_memory_order.cc
+test_memory_order_obj = $(test_memory_order_src:.cc=.o)
 
 librt_libs = $(ROOT_PATH)/bindings/cc/librt++.a
 INC += -I$(ROOT_PATH)/bindings/cc
 
 RUNTIME_LIBS := $(RUNTIME_LIBS) -lnuma
 
-all: test
+all: test_atomic test_memory_order
 
-test: $(test_obj) $(librt_libs) $(RUNTIME_DEPS)
-	$(LDXX) -o $@ $(LDFLAGS) $(test_obj) \
+test_atomic: $(test_atomic_obj) $(librt_libs) $(RUNTIME_DEPS)
+	$(LDXX) -o $@ $(LDFLAGS) $(test_atomic_obj) \
 	$(librt_libs) $(RUNTIME_LIBS)
 
-src = $(test_src)
+test_memory_order: $(test_memory_order_obj) $(librt_libs) $(RUNTIME_DEPS)
+	$(LDXX) -o $@ $(LDFLAGS) $(test_memory_order_obj) \
+	$(librt_libs) $(RUNTIME_LIBS)
+
+src = $(test_atomic_src) $(test_memory_order_src)
 obj = $(src:.cc=.o)
 dep = $(obj:.o=.d)
 
@@ -31,4 +38,4 @@ endif
 
 .PHONY: clean
 clean:
-	rm -f $(obj) $(dep) test
+	rm -f $(obj) $(dep) test_atomic test_memory_order

--- a/apps/test/test_atomic.cc
+++ b/apps/test/test_atomic.cc
@@ -1,0 +1,64 @@
+/*
+ * test_atomic.cc - tests support of std lib atomics
+ */
+
+extern "C" {
+#include <base/log.h>
+}
+
+#include "runtime.h"
+#include "sync.h"
+#include "thread.h"
+#include "timer.h"
+
+#include <atomic>
+#include <iostream>
+
+namespace {
+
+int threads;
+
+void MainHandler(void *arg) {
+  rt::WaitGroup wg(threads);
+  std::atomic<bool> ready(false);
+  std::atomic_flag winner = ATOMIC_FLAG_INIT;
+
+  for (int i = 0; i < threads; ++i) {
+    rt::Spawn([&, i]() {
+      while (!ready) {
+        rt::Yield();
+      }
+      rt::Delay(10000);
+      if (!winner.test_and_set()) {
+        log_info("thread #%d won!", i);
+      }
+      wg.Done();
+    });
+  }
+
+  ready = true;
+
+  wg.Wait();
+  log_info("test complete");
+}
+
+}  // namespace
+
+int main(int argc, char *argv[]) {
+  int ret;
+
+  if (argc != 3) {
+    std::cerr << "usage: [config_file] [#threads]" << std::endl;
+    return -EINVAL;
+  }
+
+  threads = std::stoi(argv[2], nullptr, 0);
+
+  ret = runtime_init(argv[1], MainHandler, NULL);
+  if (ret) {
+    printf("failed to start runtime\n");
+    return ret;
+  }
+
+  return 0;
+}

--- a/apps/test/test_memory_order.cc
+++ b/apps/test/test_memory_order.cc
@@ -23,6 +23,8 @@ std::atomic<int> z = ATOMIC_VAR_INIT(0);
 
 // Check rt::GetId() works.
 void PrintId() {
+  // Check rt::SleepFor() works.
+  rt::SleepFor(std::chrono::milliseconds{5 * rt::kMilliseconds});
   std::stringstream msg;
   msg << "My ID is " << rt::GetId() << "\n";
   std::cout << msg.str();

--- a/apps/test/test_memory_order.cc
+++ b/apps/test/test_memory_order.cc
@@ -65,6 +65,9 @@ void MainHandler(void *arg) {
   th3.Join();
   th4.Join();
 
+  // Check hardware concurrency.
+  log_info("the hardware concurrency is %d", th1.HardwareConcurrency());
+
   // assert(z.load() != 0);
   // z==0 will never happen
   log_info("the value of z is %d", z.load());

--- a/apps/test/test_memory_order.cc
+++ b/apps/test/test_memory_order.cc
@@ -13,6 +13,7 @@ extern "C" {
 
 #include <atomic>
 #include <iostream>
+#include <sstream>
 
 namespace {
 
@@ -20,29 +21,44 @@ std::atomic<bool> x = ATOMIC_VAR_INIT(false);
 std::atomic<bool> y = ATOMIC_VAR_INIT(false);
 std::atomic<int> z = ATOMIC_VAR_INIT(0);
 
-void write_x() { x.store(true, std::memory_order_seq_cst); }
+// Check rt::GetId() works.
+void PrintId() {
+  std::stringstream msg;
+  msg << "My ID is " << rt::GetId() << "\n";
+  std::cout << msg.str();
+}
 
-void write_y() { y.store(true, std::memory_order_seq_cst); }
+void WriteX() {
+  x.store(true, std::memory_order_seq_cst);
+  PrintId();
+}
+
+void WriteY() {
+  y.store(true, std::memory_order_seq_cst);
+  PrintId();
+}
 
 // z == 0 only if x=true, y=false
-void read_x_then_y() {
+void ReadXThenY() {
   while (!x.load(std::memory_order_seq_cst))
     ;
   if (y.load(std::memory_order_seq_cst)) ++z;
+  PrintId();
 }
 
 // z == 0 only if x=false, y=true
-void read_y_then_x() {
+void ReadYThenX() {
   while (!y.load(std::memory_order_seq_cst))
     ;
   if (x.load(std::memory_order_seq_cst)) ++z;
+  PrintId();
 }
 
 void MainHandler(void *arg) {
-  auto th1 = rt::Thread(write_x);
-  auto th2 = rt::Thread(write_y);
-  auto th3 = rt::Thread(read_x_then_y);
-  auto th4 = rt::Thread(read_y_then_x);
+  auto th1 = rt::Thread(WriteX);
+  auto th2 = rt::Thread(WriteY);
+  auto th3 = rt::Thread(ReadXThenY);
+  auto th4 = rt::Thread(ReadYThenX);
 
   th1.Join();
   th2.Join();

--- a/apps/test/test_memory_order.cc
+++ b/apps/test/test_memory_order.cc
@@ -1,0 +1,74 @@
+/*
+ * test_atomic.cc - tests support of std lib atomics
+ */
+
+extern "C" {
+#include <base/log.h>
+}
+
+#include "runtime.h"
+#include "sync.h"
+#include "thread.h"
+#include "timer.h"
+
+#include <atomic>
+#include <iostream>
+
+namespace {
+
+std::atomic<bool> x = ATOMIC_VAR_INIT(false);
+std::atomic<bool> y = ATOMIC_VAR_INIT(false);
+std::atomic<int> z = ATOMIC_VAR_INIT(0);
+
+void write_x() { x.store(true, std::memory_order_seq_cst); }
+
+void write_y() { y.store(true, std::memory_order_seq_cst); }
+
+// z == 0 only if x=true, y=false
+void read_x_then_y() {
+  while (!x.load(std::memory_order_seq_cst))
+    ;
+  if (y.load(std::memory_order_seq_cst)) ++z;
+}
+
+// z == 0 only if x=false, y=true
+void read_y_then_x() {
+  while (!y.load(std::memory_order_seq_cst))
+    ;
+  if (x.load(std::memory_order_seq_cst)) ++z;
+}
+
+void MainHandler(void *arg) {
+  auto th1 = rt::Thread(write_x);
+  auto th2 = rt::Thread(write_y);
+  auto th3 = rt::Thread(read_x_then_y);
+  auto th4 = rt::Thread(read_y_then_x);
+
+  th1.Join();
+  th2.Join();
+  th3.Join();
+  th4.Join();
+
+  // assert(z.load() != 0);
+  // z==0 will never happen
+  log_info("the value of z is %d", z.load());
+}
+
+}  // namespace
+
+int main(int argc, char *argv[]) {
+  int ret;
+
+  if (argc != 2) {
+    std::cerr << "usage: [config_file]" << std::endl;
+    return -EINVAL;
+  }
+
+  ret = runtime_init(argv[1], MainHandler, NULL);
+  if (ret) {
+    printf("failed to start runtime\n");
+    return ret;
+  }
+
+  return 0;
+}

--- a/bindings/cc/net.cc
+++ b/bindings/cc/net.cc
@@ -1,8 +1,8 @@
 #include "net.h"
 
+#include <algorithm>
 #include <cstring>
 #include <memory>
-#include <algorithm>
 
 namespace {
 

--- a/bindings/cc/net.h
+++ b/bindings/cc/net.h
@@ -42,9 +42,7 @@ class UdpConn : public NetConn {
   }
 
   // Gets the MTU-limited payload size.
-  static size_t PayloadSize() {
-    return static_cast<size_t>(udp_payload_size);
-  }
+  static size_t PayloadSize() { return static_cast<size_t>(udp_payload_size); }
 
   // Gets the local UDP address.
   netaddr LocalAddr() const { return udp_local_addr(c_); }
@@ -79,8 +77,8 @@ class UdpConn : public NetConn {
   UdpConn(udpconn_t *c) : c_(c) {}
 
   // disable move and copy.
-  UdpConn(const UdpConn&) = delete;
-  UdpConn& operator=(const UdpConn&) = delete;
+  UdpConn(const UdpConn &) = delete;
+  UdpConn &operator=(const UdpConn &) = delete;
 
   udpconn_t *c_;
 };
@@ -186,8 +184,8 @@ class TcpConn : public NetConn {
   TcpConn(tcpconn_t *c) : c_(c) {}
 
   // disable move and copy.
-  TcpConn(const TcpConn&) = delete;
-  TcpConn& operator=(const TcpConn&) = delete;
+  TcpConn(const TcpConn &) = delete;
+  TcpConn &operator=(const TcpConn &) = delete;
 
   ssize_t WritevFullRaw(const iovec *iov, int iovcnt);
   ssize_t ReadvFullRaw(const iovec *iov, int iovcnt);
@@ -223,8 +221,8 @@ class TcpQueue {
   TcpQueue(tcpqueue_t *q) : q_(q) {}
 
   // disable move and copy.
-  TcpQueue(const TcpQueue&) = delete;
-  TcpQueue& operator=(const TcpQueue&) = delete;
+  TcpQueue(const TcpQueue &) = delete;
+  TcpQueue &operator=(const TcpQueue &) = delete;
 
   tcpqueue_t *q_;
 };

--- a/bindings/cc/sync.h
+++ b/bindings/cc/sync.h
@@ -14,21 +14,21 @@ extern "C" {
 namespace rt {
 
 // Force the compiler to access a memory location.
-template<typename T>
+template <typename T>
 T volatile &access_once(T &t) {
   static_assert(std::is_integral<T>::value, "Integral required.");
   return static_cast<T volatile &>(t);
 }
 
 // Force the compiler to read a memory location.
-template<typename T>
+template <typename T>
 T read_once(const T &p) {
   static_assert(std::is_integral<T>::value, "Integral required.");
   return static_cast<const T volatile &>(p);
 }
 
 // Force the compiler to write a memory location.
-template<typename T>
+template <typename T>
 void write_once(T &p, const T &val) {
   static_assert(std::is_integral<T>::value, "Integral required.");
   static_cast<T volatile &>(p) = val;
@@ -41,12 +41,12 @@ class ThreadWaker {
   ~ThreadWaker() { assert(th_ == nullptr); }
 
   // disable copy.
-  ThreadWaker(const ThreadWaker&) = delete;
-  ThreadWaker& operator=(const ThreadWaker&) = delete;
+  ThreadWaker(const ThreadWaker &) = delete;
+  ThreadWaker &operator=(const ThreadWaker &) = delete;
 
   // allow move.
   ThreadWaker(ThreadWaker &&w) : th_(w.th_) { w.th_ = nullptr; }
-  ThreadWaker& operator=(ThreadWaker &&w) {
+  ThreadWaker &operator=(ThreadWaker &&w) {
     th_ = w.th_;
     w.th_ = nullptr;
     return *this;
@@ -79,8 +79,8 @@ class Preempt {
   ~Preempt() {}
 
   // disable move and copy.
-  Preempt(const Preempt&) = delete;
-  Preempt& operator=(const Preempt&) = delete;
+  Preempt(const Preempt &) = delete;
+  Preempt &operator=(const Preempt &) = delete;
 
   // Disables preemption.
   void Lock() { preempt_disable(); }
@@ -146,8 +146,8 @@ class Spin {
  private:
   spinlock_t lock_;
 
-  Spin(const Spin&) = delete;
-  Spin& operator=(const Spin&) = delete;
+  Spin(const Spin &) = delete;
+  Spin &operator=(const Spin &) = delete;
 };
 
 // Pthread-like mutex support.
@@ -174,8 +174,8 @@ class Mutex {
  private:
   mutex_t mu_;
 
-  Mutex(const Mutex&) = delete;
-  Mutex& operator=(const Mutex&) = delete;
+  Mutex(const Mutex &) = delete;
+  Mutex &operator=(const Mutex &) = delete;
 };
 
 // RAII lock support (works with Spin, Preempt, and Mutex).
@@ -188,8 +188,8 @@ class ScopedLock {
  private:
   L *const lock_;
 
-  ScopedLock(const ScopedLock&) = delete;
-  ScopedLock& operator=(const ScopedLock&) = delete;
+  ScopedLock(const ScopedLock &) = delete;
+  ScopedLock &operator=(const ScopedLock &) = delete;
 };
 
 using SpinGuard = ScopedLock<Spin>;
@@ -206,8 +206,8 @@ class ScopedLockAndPark {
  private:
   L *const lock_;
 
-  ScopedLockAndPark(const ScopedLockAndPark&) = delete;
-  ScopedLockAndPark& operator=(const ScopedLockAndPark&) = delete;
+  ScopedLockAndPark(const ScopedLockAndPark &) = delete;
+  ScopedLockAndPark &operator=(const ScopedLockAndPark &) = delete;
 };
 
 using SpinGuardAndPark = ScopedLockAndPark<Spin>;
@@ -232,8 +232,8 @@ class CondVar {
  private:
   condvar_t cv_;
 
-  CondVar(const CondVar&) = delete;
-  CondVar& operator=(const CondVar&) = delete;
+  CondVar(const CondVar &) = delete;
+  CondVar &operator=(const CondVar &) = delete;
 };
 
 // Golang-like waitgroup support.
@@ -262,8 +262,8 @@ class WaitGroup {
  private:
   waitgroup_t wg_;
 
-  WaitGroup(const WaitGroup&) = delete;
-  WaitGroup& operator=(const WaitGroup&) = delete;
+  WaitGroup(const WaitGroup &) = delete;
+  WaitGroup &operator=(const WaitGroup &) = delete;
 };
 
 }  // namespace rt

--- a/bindings/cc/thread.h
+++ b/bindings/cc/thread.h
@@ -6,8 +6,10 @@ extern "C" {
 #include <base/assert.h>
 #include <base/thread.h>
 #include <runtime/sync.h>
+#include <runtime/timer.h>
 }
 
+#include <chrono>
 #include <functional>
 
 namespace rt {
@@ -141,9 +143,18 @@ inline std::basic_ostream<_CharT, _Traits>& operator<<(
     return out << id.thread_id_;
 }
 
-// Called from a running thread.
+// Called from a running thread. Similar to std::this_thread::get_id()
 inline Thread::Id GetId() noexcept {
   return Thread::Id(get_uthread_specific());
+}
+
+// Called from a running thread. Similar to std::this_thread::sleep_for
+template <typename _Rep, typename _Period>
+inline void SleepFor(const std::chrono::duration<_Rep, _Period>& time) {
+  if (time <= time.zero()) return;
+  auto micros =
+      std::chrono::duration_cast<std::chrono::microseconds>(time).count();
+  timer_sleep(static_cast<uint64_t>(micros));
 }
 
 }  // namespace rt

--- a/bindings/cc/thread.h
+++ b/bindings/cc/thread.h
@@ -14,16 +14,11 @@ namespace rt {
 namespace thread_internal {
 
 struct join_data {
-  join_data(std::function<void()>&& func)
-      : done_(false), waiter_(nullptr), func_(std::move(func)) {
-    spin_lock_init(&lock_);
-  }
-  join_data(const std::function<void()>& func)
-      : done_(false), waiter_(nullptr), func_(func) {
-    spin_lock_init(&lock_);
-  }
+  join_data(std::function<void()>&& func);
+  join_data(const std::function<void()>& func);
 
   spinlock_t lock_;
+  thread_id_t id_;
   bool done_;
   thread_t* waiter_;
   std::function<void()> func_;
@@ -96,7 +91,7 @@ class Thread {
     thread_id_t thread_id_;
 
    public:
-    Id() noexcept : thread_id_() {}
+    Id() noexcept : thread_id_(-1) {}
     explicit Id(thread_id_t id) : thread_id_(id) {}
 
    private:
@@ -139,6 +134,11 @@ inline std::basic_ostream<_CharT, _Traits>& operator<<(
     return out << "Thread::Id of a non-executing thread";
   else
     return out << id.thread_id_;
+}
+
+// Called from a running thread.
+inline Thread::Id GetId() noexcept {
+  return Thread::Id(get_uthread_specific());
 }
 
 }  // namespace rt

--- a/bindings/cc/thread.h
+++ b/bindings/cc/thread.h
@@ -110,6 +110,9 @@ class Thread {
 
   Thread::Id GetId() const noexcept { return id_; }
 
+  // Similar to std::thread::hardware_concurrency().
+  static unsigned int HardwareConcurrency() noexcept { return nrks; }
+
  private:
   Id id_;
   thread_internal::join_data* join_data_;

--- a/bindings/cc/thread.h
+++ b/bindings/cc/thread.h
@@ -86,13 +86,15 @@ class Thread {
   // Detaches the thread, indicating it won't be joined in the future.
   void Detach();
 
+  typedef thread_id_t native_handle_type;
+
   // Similar to std::thread::id.
   class Id {
-    thread_id_t thread_id_;
+    native_handle_type thread_id_;
 
    public:
     Id() noexcept : thread_id_(-1) {}
-    explicit Id(thread_id_t id) : thread_id_(id) {}
+    explicit Id(native_handle_type id) : thread_id_(id) {}
 
    private:
     friend class Thread;

--- a/inc/runtime/thread.h
+++ b/inc/runtime/thread.h
@@ -12,7 +12,7 @@
 struct thread;
 typedef void (*thread_fn_t)(void *arg);
 typedef struct thread thread_t;
-typedef unsigned int thread_id_t;
+typedef uint64_t thread_id_t;
 
 
 /*

--- a/inc/runtime/thread.h
+++ b/inc/runtime/thread.h
@@ -12,6 +12,7 @@
 struct thread;
 typedef void (*thread_fn_t)(void *arg);
 typedef struct thread thread_t;
+typedef unsigned int thread_id_t;
 
 
 /*

--- a/inc/runtime/thread.h
+++ b/inc/runtime/thread.h
@@ -29,6 +29,7 @@ extern thread_t *thread_create_with_buf(thread_fn_t fn, void **buf, size_t len);
 
 extern __thread thread_t *__self;
 extern __thread unsigned int kthread_idx;
+extern unsigned int nrks;
 
 static inline unsigned int get_current_affinity(void)
 {


### PR DESCRIPTION
Idea is to replace all occurrences of `std::thread` in `folly` with `rt::Thread`. A successful compilation and a demo would be the aim of this PR.

C++11 Source: https://code.woboq.org/gcc/libstdc++-v3/src/c++11/thread.cc.html