### PR TITLE
Check atomics support 

### DIFF
--- a/apps/test/Makefile
+++ b/apps/test/Makefile
@@ -1,0 +1,34 @@
+# Makefile for simple app
+ROOT_PATH=../..
+include $(ROOT_PATH)/build/shared.mk
+
+test_src = test_atomic.cc
+test_obj = $(test_src:.cc=.o)
+
+librt_libs = $(ROOT_PATH)/bindings/cc/librt++.a
+INC += -I$(ROOT_PATH)/bindings/cc
+
+RUNTIME_LIBS := $(RUNTIME_LIBS) -lnuma
+
+all: test
+
+test: $(test_obj) $(librt_libs) $(RUNTIME_DEPS)
+	$(LDXX) -o $@ $(LDFLAGS) $(test_obj) \
+	$(librt_libs) $(RUNTIME_LIBS)
+
+src = $(test_src)
+obj = $(src:.cc=.o)
+dep = $(obj:.o=.d)
+
+ifneq ($(MAKECMDGOALS),clean)
+-include $(dep)
+endif
+
+%.d: %.cc
+	@$(CXX) $(CXXFLAGS) $< -MM -MT $(@:.d=.o) >$@
+%.o: %.cc
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+.PHONY: clean
+clean:
+	rm -f $(obj) $(dep) test

--- a/apps/test/Makefile
+++ b/apps/test/Makefile
@@ -2,21 +2,28 @@
 ROOT_PATH=../..
 include $(ROOT_PATH)/build/shared.mk
 
-test_src = test_atomic.cc
-test_obj = $(test_src:.cc=.o)
+test_atomic_src = test_atomic.cc
+test_atomic_obj = $(test_atomic_src:.cc=.o)
+
+test_memory_order_src = test_memory_order.cc
+test_memory_order_obj = $(test_memory_order_src:.cc=.o)
 
 librt_libs = $(ROOT_PATH)/bindings/cc/librt++.a
 INC += -I$(ROOT_PATH)/bindings/cc
 
 RUNTIME_LIBS := $(RUNTIME_LIBS) -lnuma
 
-all: test
+all: test_atomic test_memory_order
 
-test: $(test_obj) $(librt_libs) $(RUNTIME_DEPS)
-	$(LDXX) -o $@ $(LDFLAGS) $(test_obj) \
+test_atomic: $(test_atomic_obj) $(librt_libs) $(RUNTIME_DEPS)
+	$(LDXX) -o $@ $(LDFLAGS) $(test_atomic_obj) \
 	$(librt_libs) $(RUNTIME_LIBS)
 
-src = $(test_src)
+test_memory_order: $(test_memory_order_obj) $(librt_libs) $(RUNTIME_DEPS)
+	$(LDXX) -o $@ $(LDFLAGS) $(test_memory_order_obj) \
+	$(librt_libs) $(RUNTIME_LIBS)
+
+src = $(test_atomic_src) $(test_memory_order_src)
 obj = $(src:.cc=.o)
 dep = $(obj:.o=.d)
 
@@ -31,4 +38,4 @@ endif
 
 .PHONY: clean
 clean:
-	rm -f $(obj) $(dep) test
+	rm -f $(obj) $(dep) test_atomic test_memory_order

--- a/apps/test/test_atomic.cc
+++ b/apps/test/test_atomic.cc
@@ -1,0 +1,64 @@
+/*
+ * test_atomic.cc - tests support of std lib atomics
+ */
+
+extern "C" {
+#include <base/log.h>
+}
+
+#include "runtime.h"
+#include "sync.h"
+#include "thread.h"
+#include "timer.h"
+
+#include <atomic>
+#include <iostream>
+
+namespace {
+
+int threads;
+
+void MainHandler(void *arg) {
+  rt::WaitGroup wg(threads);
+  std::atomic<bool> ready(false);
+  std::atomic_flag winner = ATOMIC_FLAG_INIT;
+
+  for (int i = 0; i < threads; ++i) {
+    rt::Spawn([&, i]() {
+      while (!ready) {
+        rt::Yield();
+      }
+      rt::Delay(10000);
+      if (!winner.test_and_set()) {
+        log_info("thread #%d won!", i);
+      }
+      wg.Done();
+    });
+  }
+
+  ready = true;
+
+  wg.Wait();
+  log_info("test complete");
+}
+
+}  // namespace
+
+int main(int argc, char *argv[]) {
+  int ret;
+
+  if (argc != 3) {
+    std::cerr << "usage: [config_file] [#threads]" << std::endl;
+    return -EINVAL;
+  }
+
+  threads = std::stoi(argv[2], nullptr, 0);
+
+  ret = runtime_init(argv[1], MainHandler, NULL);
+  if (ret) {
+    printf("failed to start runtime\n");
+    return ret;
+  }
+
+  return 0;
+}

--- a/apps/test/test_memory_order.cc
+++ b/apps/test/test_memory_order.cc
@@ -13,6 +13,7 @@ extern "C" {
 
 #include <atomic>
 #include <iostream>
+#include <sstream>
 
 namespace {
 
@@ -20,29 +21,44 @@ std::atomic<bool> x = ATOMIC_VAR_INIT(false);
 std::atomic<bool> y = ATOMIC_VAR_INIT(false);
 std::atomic<int> z = ATOMIC_VAR_INIT(0);
 
-void write_x() { x.store(true, std::memory_order_seq_cst); }
+// Check rt::GetId() works.
+void PrintId() {
+  std::stringstream msg;
+  msg << "My ID is " << rt::GetId() << "\n";
+  std::cout << msg.str();
+}
 
-void write_y() { y.store(true, std::memory_order_seq_cst); }
+void WriteX() {
+  x.store(true, std::memory_order_seq_cst);
+  PrintId();
+}
+
+void WriteY() {
+  y.store(true, std::memory_order_seq_cst);
+  PrintId();
+}
 
 // z == 0 only if x=true, y=false
-void read_x_then_y() {
+void ReadXThenY() {
   while (!x.load(std::memory_order_seq_cst))
     ;
   if (y.load(std::memory_order_seq_cst)) ++z;
+  PrintId();
 }
 
 // z == 0 only if x=false, y=true
-void read_y_then_x() {
+void ReadYThenX() {
   while (!y.load(std::memory_order_seq_cst))
     ;
   if (x.load(std::memory_order_seq_cst)) ++z;
+  PrintId();
 }
 
 void MainHandler(void *arg) {
-  auto th1 = rt::Thread(write_x);
-  auto th2 = rt::Thread(write_y);
-  auto th3 = rt::Thread(read_x_then_y);
-  auto th4 = rt::Thread(read_y_then_x);
+  auto th1 = rt::Thread(WriteX);
+  auto th2 = rt::Thread(WriteY);
+  auto th3 = rt::Thread(ReadXThenY);
+  auto th4 = rt::Thread(ReadYThenX);
 
   th1.Join();
   th2.Join();

--- a/apps/test/test_memory_order.cc
+++ b/apps/test/test_memory_order.cc
@@ -1,0 +1,74 @@
+/*
+ * test_atomic.cc - tests support of std lib atomics
+ */
+
+extern "C" {
+#include <base/log.h>
+}
+
+#include "runtime.h"
+#include "sync.h"
+#include "thread.h"
+#include "timer.h"
+
+#include <atomic>
+#include <iostream>
+
+namespace {
+
+std::atomic<bool> x = ATOMIC_VAR_INIT(false);
+std::atomic<bool> y = ATOMIC_VAR_INIT(false);
+std::atomic<int> z = ATOMIC_VAR_INIT(0);
+
+void write_x() { x.store(true, std::memory_order_seq_cst); }
+
+void write_y() { y.store(true, std::memory_order_seq_cst); }
+
+// z == 0 only if x=true, y=false
+void read_x_then_y() {
+  while (!x.load(std::memory_order_seq_cst))
+    ;
+  if (y.load(std::memory_order_seq_cst)) ++z;
+}
+
+// z == 0 only if x=false, y=true
+void read_y_then_x() {
+  while (!y.load(std::memory_order_seq_cst))
+    ;
+  if (x.load(std::memory_order_seq_cst)) ++z;
+}
+
+void MainHandler(void *arg) {
+  auto th1 = rt::Thread(write_x);
+  auto th2 = rt::Thread(write_y);
+  auto th3 = rt::Thread(read_x_then_y);
+  auto th4 = rt::Thread(read_y_then_x);
+
+  th1.Join();
+  th2.Join();
+  th3.Join();
+  th4.Join();
+
+  // assert(z.load() != 0);
+  // z==0 will never happen
+  log_info("the value of z is %d", z.load());
+}
+
+}  // namespace
+
+int main(int argc, char *argv[]) {
+  int ret;
+
+  if (argc != 2) {
+    std::cerr << "usage: [config_file]" << std::endl;
+    return -EINVAL;
+  }
+
+  ret = runtime_init(argv[1], MainHandler, NULL);
+  if (ret) {
+    printf("failed to start runtime\n");
+    return ret;
+  }
+
+  return 0;
+}

--- a/bindings/cc/thread.h
+++ b/bindings/cc/thread.h
@@ -14,16 +14,11 @@ namespace rt {
 namespace thread_internal {
 
 struct join_data {
-  join_data(std::function<void()>&& func)
-      : done_(false), waiter_(nullptr), func_(std::move(func)) {
-    spin_lock_init(&lock_);
-  }
-  join_data(const std::function<void()>& func)
-      : done_(false), waiter_(nullptr), func_(func) {
-    spin_lock_init(&lock_);
-  }
+  join_data(std::function<void()>&& func);
+  join_data(const std::function<void()>& func);
 
   spinlock_t lock_;
+  thread_id_t id_;
   bool done_;
   thread_t* waiter_;
   std::function<void()> func_;
@@ -96,7 +91,7 @@ class Thread {
     thread_id_t thread_id_;
 
    public:
-    Id() noexcept : thread_id_() {}
+    Id() noexcept : thread_id_(-1) {}
     explicit Id(thread_id_t id) : thread_id_(id) {}
 
    private:
@@ -139,6 +134,11 @@ inline std::basic_ostream<_CharT, _Traits>& operator<<(
     return out << "Thread::Id of a non-executing thread";
   else
     return out << id.thread_id_;
+}
+
+// Called from a running thread.
+inline Thread::Id GetId() noexcept {
+  return Thread::Id(get_uthread_specific());
 }
 
 }  // namespace rt

--- a/inc/runtime/thread.h
+++ b/inc/runtime/thread.h
@@ -12,7 +12,7 @@
 struct thread;
 typedef void (*thread_fn_t)(void *arg);
 typedef struct thread thread_t;
-typedef unsigned int thread_id_t;
+typedef uint64_t thread_id_t;
 
 
 /*


### PR DESCRIPTION
Check if std::atomic works fine using Shenango threads. It does work fine.

```
saubhik@node-0:/proj/quic-server-PG0/users/saubhik/caladan/apps/test$ ./test ../../server.config 100
CPU 11| <5> cpu: detected 20 cores, 1 nodes
CPU 11| <5> time: detected 2394 ticks / us
[  0.000646] CPU 11| <5> loading configuration from '../../server.config'
[  0.001075] CPU 11| <5> cfg: provisioned 4 cores (4 guaranteed, 0 burstable, 0 spinning)
[  0.001087] CPU 11| <5> cfg: task is latency critical (LC)
[  0.001096] CPU 11| <5> cfg: THRESH_QD: 10, THRESH_HT: 0
[  0.001105] CPU 11| <5> cfg: storage disabled, directpath disabled
[  0.001124] CPU 11| <5> process pid: 13084
[  0.030245] CPU 11| <5> net: started network stack
[  0.030258] CPU 11| <5> net: using the following configuration:
[  0.030261] CPU 11| <5>   addr:        192.168.1.3
[  0.030266] CPU 11| <5>   netmask:     255.255.255.0
[  0.030269] CPU 11| <5>   gateway:     192.168.1.1
[  0.030272] CPU 11| <5>   mac:         D2:35:79:2F:2F:3B
[  0.030278] CPU 11| <5>   mtu:         1500
[  0.030390] CPU 11| <5> thread: created thread 0
[  0.030451] CPU 11| <5> spawning 4 kthreads
[  0.030548] CPU 12| <5> thread: created thread 1
[  0.030596] CPU 13| <5> thread: created thread 2
[  0.030663] CPU 15| <5> thread: created thread 3
[  0.045950] CPU 11| <5> thread #0 won!
[  0.285969] CPU 11| <5> test complete
[  0.285975] CPU 11| <5> init: shutting down -> SUCCESS
saubhik@node-0:/proj/quic-server-PG0/users/saubhik/caladan/apps/test$ ./test ../../server.config 100
CPU 01| <5> cpu: detected 20 cores, 1 nodes
CPU 01| <5> time: detected 2394 ticks / us
[  0.000656] CPU 01| <5> loading configuration from '../../server.config'
[  0.001013] CPU 01| <5> cfg: provisioned 4 cores (4 guaranteed, 0 burstable, 0 spinning)
[  0.001025] CPU 01| <5> cfg: task is latency critical (LC)
[  0.001033] CPU 01| <5> cfg: THRESH_QD: 10, THRESH_HT: 0
[  0.001040] CPU 01| <5> cfg: storage disabled, directpath disabled
[  0.001058] CPU 01| <5> process pid: 13108
[  0.030289] CPU 01| <5> net: started network stack
[  0.030302] CPU 01| <5> net: using the following configuration:
[  0.030305] CPU 01| <5>   addr:        192.168.1.3
[  0.030308] CPU 01| <5>   netmask:     255.255.255.0
[  0.030312] CPU 01| <5>   gateway:     192.168.1.1
[  0.030314] CPU 01| <5>   mac:         2A:47:4C:00:38:0E
[  0.030321] CPU 01| <5>   mtu:         1500
[  0.030431] CPU 01| <5> thread: created thread 0
[  0.030492] CPU 01| <5> spawning 4 kthreads
[  0.030621] CPU 12| <5> thread: created thread 1
[  0.030634] CPU 13| <5> thread: created thread 2
[  0.030684] CPU 14| <5> thread: created thread 3
[  0.045864] CPU 11| <5> thread #2 won!
[  0.285884] CPU 11| <5> test complete
[  0.285890] CPU 11| <5> init: shutting down -> SUCCESS
```

Also, `std::memory_order` seems to work fine. But cannot say deterministically.